### PR TITLE
ridgeback_navigation: remove deprecated footprint layer

### DIFF
--- a/ridgeback_navigation/params/costmap_common_params.yaml
+++ b/ridgeback_navigation/params/costmap_common_params.yaml
@@ -14,7 +14,6 @@ footprint: [[-0.21, -0.165], [-0.21, 0.165], [0.21, 0.165], [0.21, -0.165]]
 footprint_padding: 0.1
 
 plugins:
-- {name: footprint_layer, type: "costmap_2d::FootprintLayer"}
 - {name: obstacles_layer, type: "costmap_2d::ObstacleLayer"}
 - {name: inflater_layer, type: "costmap_2d::InflationLayer"}
 

--- a/ridgeback_navigation/params/map_nav_params/global_costmap_params.yaml
+++ b/ridgeback_navigation/params/map_nav_params/global_costmap_params.yaml
@@ -13,7 +13,5 @@ global_costmap:
    
    plugins:
    - {name: static_layer, type: "costmap_2d::StaticLayer"}
-   - {name: footprint_layer, type: "costmap_2d::FootprintLayer"}
    - {name: obstacles_layer, type: "costmap_2d::ObstacleLayer"}
    - {name: inflater_layer, type: "costmap_2d::InflationLayer"}
-


### PR DESCRIPTION
roslaunch ridgeback_navigation move_base.launch failed since the footprint layer was removed from ros-planning/navigation, see https://github.com/ros-planning/navigation/pull/368

Side question: What is the reason for the CATKIN_IGNORE in ridgeback_navigation?
