### PR TITLE
Fixed missing calculation of wheels_k_ in MecanumDriveController

### DIFF
--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -413,6 +413,15 @@ bool MecanumDriveController::setWheelParamsFromUrdf(ros::NodeHandle& root_nh,
       wheels_k_ = (-(-wheel0_x - wheel0_y) - (wheel1_x - wheel1_y) + (-wheel2_x - wheel2_y) + (wheel3_x - wheel3_y))
                   / 4.0;
     }
+    else
+    {
+      ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
+      ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
+
+      // The seperation is the total distance between the wheels in X and Y.
+
+      wheels_k_ = (wheel_separation_x_ + wheel_separation_y_) / 2.0;
+    }
 
     if (lookup_wheel_radius)
     {
@@ -441,15 +450,6 @@ bool MecanumDriveController::setWheelParamsFromUrdf(ros::NodeHandle& root_nh,
 
       wheels_radius_ = wheel0_radius;
     }
-  }
-  else
-  {
-    ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
-    ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
-
-    // The seperation is the total distance between the wheels in X and Y.
-
-    wheels_k_ = (wheel_separation_x_ + wheel_separation_y_) / 2.0;
   }
 
   ROS_INFO_STREAM("Wheel radius: " << wheels_radius_);


### PR DESCRIPTION
This is a regression from daa4bc9050f786ed092fab911dd217da6febeae0 (#21).

It caused the published odometry to contain NaN values because of a division by zero if `wheels_k_` was not set from the wheel separation on the parameter server.