### PR TITLE
fixed if loop when both wheel separation in x and y is provided.

### DIFF
--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -451,6 +451,15 @@ bool MecanumDriveController::setWheelParamsFromUrdf(ros::NodeHandle& root_nh,
       wheels_radius_ = wheel0_radius;
     }
   }
+  else
+  {
+    ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
+    ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
+
+    // The seperation is the total distance between the wheels in X and Y.
+
+    wheels_k_ = (wheel_separation_x_ + wheel_separation_y_) / 2.0;
+    }
 
   ROS_INFO_STREAM("Wheel radius: " << wheels_radius_);
 


### PR DESCRIPTION
When both wheel_separation_x and wheel_separation_y are provide by YAML file.  
`  if (lookup_wheel_separation || lookup_wheel_radius)`
is not executed and as a result wheels_k_ parameter remains zero. 

