### PR TITLE
assign wheels_k_ with wheel_separation_x_ and wheel_separation_y_

### DIFF
--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -455,6 +455,13 @@ bool MecanumDriveController::setWheelParamsFromUrdf(ros::NodeHandle& root_nh,
       wheels_radius_ = wheel0_radius;
     }
   }
+  else
+  {
+    ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
+    ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
+    // The seperation is the total distance between the wheels in X and Y.
+    wheels_k_ = (wheel_separation_x_ + wheel_separation_y_) / 2.0;
+  }
 
   ROS_INFO_STREAM("Wheel radius: " << wheels_radius_);
 


### PR DESCRIPTION
The following codes shouldn't be removed. Otherwise wheels_k_ would remain 0 when the parameters wheel_separation_x_ and wheel_separation_y_ exist.
```cpp
  bool lookup_wheel_separation = !(has_wheel_separation_x && has_wheel_separation_y);
  bool lookup_wheel_radius = !controller_nh.getParam("wheel_radius", wheels_radius_);

  // Avoid URDF requirement if wheel separation and radius already specified
  if (lookup_wheel_separation || lookup_wheel_radius)
  {
  ...
  }
  else
  {
    ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
    ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
    // The seperation is the total distance between the wheels in X and Y.
    wheels_k_ = (wheel_separation_x_ + wheel_separation_y_) / 2.0;
  }
```