### PR TITLE
Revert "Add namespace to gazebo plugin, it works well in multi robots case now"

### DIFF
--- a/ridgeback_description/urdf/ridgeback.gazebo
+++ b/ridgeback_description/urdf/ridgeback.gazebo
@@ -25,7 +25,6 @@
       <updateRate>50.0</updateRate>
       <bodyName>imu_link</bodyName>
       <topicName>imu/data</topicName>
-      <frameId>$(arg namespace)/base_link</frameId>
       <accelDrift>0.005 0.005 0.005</accelDrift>
       <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
       <rateDrift>0.00005 0.00005 0.00005</rateDrift>
@@ -36,7 +35,7 @@
 
     <plugin name="gazebo_ros_joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
       <jointName>front_rocker</jointName>
-      <robotNamespace>/$(arg namespace)</robotNamespace>
+      <robotNamespace>/</robotNamespace>
       <updateRate>50.0</updateRate>
     </plugin>
   </gazebo>

--- a/ridgeback_description/urdf/ridgeback.gazebo
+++ b/ridgeback_description/urdf/ridgeback.gazebo
@@ -6,7 +6,7 @@
     </plugin>
 
     <plugin name="ridgeback_ros_force_based_move" filename="libridgeback_ros_force_based_move.so">
-      <robotNamespace>/$(arg namespace)</robotNamespace>
+      <robotNamespace>/</robotNamespace>
       <commandTopic>cmd_vel</commandTopic>
       <odometryTopic>odom</odometryTopic>
       <odometryFrame>odom</odometryFrame>
@@ -21,7 +21,7 @@
     </plugin>
 
     <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>/$(arg namespace)</robotNamespace>
+      <robotNamespace>/</robotNamespace>
       <updateRate>50.0</updateRate>
       <bodyName>imu_link</bodyName>
       <topicName>imu/data</topicName>


### PR DESCRIPTION
This reverts commit b47792baf1956bb0121d8e33cee096c37804f8c9, see issue #36.