### PR TITLE
Fix PS4 device to match updated udev rules for bionic

### DIFF
--- a/ridgeback_control/config/teleop_ps4.yaml
+++ b/ridgeback_control/config/teleop_ps4.yaml
@@ -15,4 +15,4 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1
   autorepeat_rate: 20
-  dev: /dev/input/ds4x
+  dev: /dev/input/ps4


### PR DESCRIPTION
The updated udev rules for the PS4 controller don't use ds4drv anymore, so the controller symlinks to /dev/input/ps4 now.  This change enables correct PS4 controller input on Bionic with ROS Melodic.