### PR TITLE
[Nav][AMCL] adds args to pass initial pose to AMCL

### DIFF
--- a/ridgeback_navigation/launch/amcl_demo.launch
+++ b/ridgeback_navigation/launch/amcl_demo.launch
@@ -1,13 +1,20 @@
 <launch>
 
   <!-- Run the map server -->
- <arg name="map_file" default="$(find ridgeback_navigation)/maps/ridgeback_race.yaml"/>
- <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
+  <arg name="map_file" default="$(find ridgeback_navigation)/maps/ridgeback_race.yaml"/>
+  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
   <!--- Run AMCL -->
- <include file="$(find ridgeback_navigation)/launch/include/amcl.launch" />
+  <arg name="initial_pose_x" default="0.0" />
+  <arg name="initial_pose_y" default="0.0" />
+  <arg name="initial_pose_a" default="0.0" />
+  <include file="$(find ridgeback_navigation)/launch/include/amcl.launch" >
+    <arg name="initial_pose_x" value="$(arg initial_pose_x)" />
+    <arg name="initial_pose_y" value="$(arg initial_pose_y)" />
+    <arg name="initial_pose_a" value="$(arg initial_pose_a)" />
+  </include>
 
   <!--- Run Move Base -->
- <include file="$(find ridgeback_navigation)/launch/include/move_base.launch" />
+  <include file="$(find ridgeback_navigation)/launch/include/move_base.launch" />
 
 </launch>

--- a/ridgeback_navigation/launch/include/amcl.launch
+++ b/ridgeback_navigation/launch/include/amcl.launch
@@ -2,6 +2,9 @@
 
   <arg name="use_map_topic" default="false"/>
   <arg name="scan_topic" default="front/scan" />
+  <arg name="initial_pose_x" default="0.0" />
+  <arg name="initial_pose_y" default="0.0" />
+  <arg name="initial_pose_a" default="0.0" />
 
   <node pkg="amcl" type="amcl" name="amcl">
     <param name="use_map_topic" value="$(arg use_map_topic)"/>
@@ -47,9 +50,9 @@
     <!--Exponential decay rate for the fast average weight filter, used in deciding when to recover by adding random poses. A good value might be 0.1. -->
     <param name="recovery_alpha_fast" value="0.1"/>
     <!-- Initial pose mean -->
-    <param name="initial_pose_x" value="0.0" />
-    <param name="initial_pose_y" value="0.0" />
-    <param name="initial_pose_a" value="0.0" />
+    <param name="initial_pose_x" value="$(arg initial_pose_x)" />
+    <param name="initial_pose_y" value="$(arg initial_pose_y)" />
+    <param name="initial_pose_a" value="$(arg initial_pose_a)" />
     <!-- When set to true, AMCL will subscribe to the map topic rather than making a service call to receive its map.-->
     <param name="receive_map_topic" value="true"/>
     <!--  When set to true, AMCL will only use the first map it subscribes to, rather than updating each time a new one is received. -->


### PR DESCRIPTION
This adds the ros launch arguments initial_pose_x, initial_pose_y and
initial_pose_a which are passed through to the AMCL params of the same
name.

These args are defaulted to 0.0, 0.0, 0.0 as they were before so they
should have no changing effects if not set.

These args can be used to pre-seed the initial localization estimate.
Which is useful when you know where in the map you've spawned the robot.