### PR TITLE
Add CODEOWNERS to automate github review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file allows changes in specific paths to automatically request review from individuals.
+# See https://help.github.com/articles/about-code-owners/ for details.
+
+# Default all changes will request review from:
+* @tonybaltovski


### PR DESCRIPTION
@tonybaltovski from the contributors graph it looks like you are the
owner of this project. But if you have internal github teams setup you
can edit this PR and share the workload.