### PR TITLE
Nav demo improvements

### DIFF
--- a/ridgeback_navigation/launch/amcl_demo.launch
+++ b/ridgeback_navigation/launch/amcl_demo.launch
@@ -1,11 +1,14 @@
 <launch>
+  <arg name="scan_topic" default="front/scan" />
 
   <!-- Run the map server -->
  <arg name="map_file" default="$(find ridgeback_navigation)/maps/ridgeback_race.yaml"/>
  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
   <!--- Run AMCL -->
- <include file="$(find ridgeback_navigation)/launch/include/amcl.launch" />
+ <include file="$(find ridgeback_navigation)/launch/include/amcl.launch">
+   <arg name="scan_topic" value="$(arg scan_topic)" />
+ </include>
 
   <!--- Run Move Base -->
  <include file="$(find ridgeback_navigation)/launch/include/move_base.launch" />

--- a/ridgeback_navigation/launch/gmapping_demo.launch
+++ b/ridgeback_navigation/launch/gmapping_demo.launch
@@ -1,7 +1,10 @@
 <launch>
+  <arg name="scan_topic" default="front/scan" />
 
   <!--- Run gmapping -->
-  <include file="$(find ridgeback_navigation)/launch/include/gmapping.launch" />
+  <include file="$(find ridgeback_navigation)/launch/include/gmapping.launch">
+    <arg name="scan_topic" value="$(arg scan_topic)" />
+  </include>
 
   <!--- Run Move Base -->
   <include file="$(find ridgeback_navigation)/launch/include/move_base.launch" />


### PR DESCRIPTION
Expose the scan_topic in the amcl + gmapping demos. Unlike the other platforms, we don't have a RIDGEBACK_LASER_TOPIC env var to leverage, so stick with front/scan as the default.