### PR TITLE
Add envar to set joy device

### DIFF
--- a/ridgeback_control/config/teleop_ps3.yaml
+++ b/ridgeback_control/config/teleop_ps3.yaml
@@ -15,3 +15,4 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1
   autorepeat_rate: 20
+  dev: /dev/input/js0

--- a/ridgeback_control/config/teleop_ps4.yaml
+++ b/ridgeback_control/config/teleop_ps4.yaml
@@ -15,4 +15,3 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1
   autorepeat_rate: 20
-  dev: /dev/input/ps4

--- a/ridgeback_control/launch/control.launch
+++ b/ridgeback_control/launch/control.launch
@@ -1,10 +1,6 @@
 <launch>
   <rosparam command="load" file="$(find ridgeback_control)/config/control.yaml" />
 
-  <group if="$(optenv RIDGEBACK_CONTROL_EXTRAS 0)" >
-    <rosparam command="load" file="$(env RIDGEBACK_CONTROL_EXTRAS_PATH)" />
-  </group>
-
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
         args="ridgeback_joint_publisher ridgeback_velocity_controller" />
 
@@ -12,4 +8,8 @@
 
   <node pkg="topic_tools" type="relay" name="cmd_vel_relay"
         args="cmd_vel ridgeback_velocity_controller/cmd_vel" />
+
+  <group if="$(optenv RIDGEBACK_CONTROL_EXTRAS 0)" >
+    <rosparam command="load" file="$(env RIDGEBACK_CONTROL_EXTRAS_PATH)" />
+  </group>
 </launch>

--- a/ridgeback_control/launch/teleop.launch
+++ b/ridgeback_control/launch/teleop.launch
@@ -11,7 +11,6 @@
 
     <group if="$(optenv RIDGEBACK_PS3 0)" >
       <rosparam command="load" file="$(find ridgeback_control)/config/teleop_ps3.yaml" />
-      <param name="joy_node/dev" value="$(arg joy_dev)" />
     </group>
 
     <node pkg="joy" type="joy_node" name="joy_node" />

--- a/ridgeback_control/launch/teleop.launch
+++ b/ridgeback_control/launch/teleop.launch
@@ -1,11 +1,12 @@
 <launch>
-  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="joy_dev" default="$(optenv RIDGEBACK_JOY_DEVICE /dev/input/ps4)" />
   <arg name="joystick" default="true" />
 
   <group ns="bluetooth_teleop" if="$(arg joystick)">
 
     <group unless="$(optenv RIDGEBACK_PS3 0)" >
       <rosparam command="load" file="$(find ridgeback_control)/config/teleop_ps4.yaml" />
+      <param name="joy_node/dev" value="$(arg joy_dev)" />
     </group>
 
     <group if="$(optenv RIDGEBACK_PS3 0)" >


### PR DESCRIPTION
Add the RIDGEBACK_JOY_DEVICE envar, move the control_extras to the end of control.launch so it can be used to override anything.  See RPSW-1133