### PR TITLE
Add twist_mux to ridgeback_control

### DIFF
--- a/ridgeback_control/config/twist_mux.yaml
+++ b/ridgeback_control/config/twist_mux.yaml
@@ -1,0 +1,22 @@
+topics:
+- name    : joy
+  topic   : joy_teleop/cmd_vel
+  timeout : 0.5
+  priority: 10
+- name    : bt_joy
+  topic   : bluetooth_teleop/cmd_vel
+  timeout : 0.5
+  priority: 9
+- name    : interactive_marker
+  topic   : twist_marker_server/cmd_vel
+  timeout : 0.5
+  priority: 8
+- name    : external
+  topic   : cmd_vel
+  timeout : 0.5
+  priority: 1
+locks:
+- name    : e_stop
+  topic   : e_stop
+  timeout : 0.0
+  priority: 255

--- a/ridgeback_control/launch/control.launch
+++ b/ridgeback_control/launch/control.launch
@@ -6,8 +6,10 @@
 
   <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization" />
 
-  <node pkg="topic_tools" type="relay" name="cmd_vel_relay"
-        args="cmd_vel ridgeback_velocity_controller/cmd_vel" />
+  <node pkg="twist_mux" type="twist_mux" name="twist_mux">
+    <rosparam command="load" file="$(find ridgeback_control)/config/twist_mux.yaml" />
+    <remap from="cmd_vel_out" to="ridgeback_velocity_controller/cmd_vel"/>
+  </node>
 
   <group if="$(optenv RIDGEBACK_CONTROL_EXTRAS 0)" >
     <rosparam command="load" file="$(env RIDGEBACK_CONTROL_EXTRAS_PATH)" />

--- a/ridgeback_control/launch/teleop.launch
+++ b/ridgeback_control/launch/teleop.launch
@@ -15,15 +15,12 @@
 
     <node pkg="joy" type="joy_node" name="joy_node" />
 
-    <node pkg="teleop_twist_joy" type="teleop_node" name="teleop_twist_joy">
-      <remap from="cmd_vel" to="/cmd_vel" />
-    </node>
+    <node pkg="teleop_twist_joy" type="teleop_node" name="teleop_twist_joy" />
   </group>
 
   <arg name="config" default="planar" />
 
   <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server">
-    <remap from="twist_marker_server/cmd_vel" to="/cmd_vel" />
     <rosparam command="load" file="$(find interactive_marker_twist_server)/config/$(arg config).yaml" />
   </node>
 

--- a/ridgeback_control/package.xml
+++ b/ridgeback_control/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>twist_mux</exec_depend>
 
   <test_depend>roslaunch</test_depend>
 


### PR DESCRIPTION
Tested by pairing PS4 controller to laptop, running `roslaunch ridgeback_control teleop.launch`, and seeing drive commands published on `/bluetooth_teleop/cmd_vel`