### PR TITLE
Add teleop turbo support

### DIFF
--- a/ridgeback_control/config/teleop_ps4.yaml
+++ b/ridgeback_control/config/teleop_ps4.yaml
@@ -7,8 +7,8 @@ teleop_twist_joy:
     x: 0.4
     y: 0.4
   scale_linear_turbo:
-    x: 1.1
-    y: 1.1
+    x: 0.4
+    y: 0.4
   axis_angular:
     yaw: 3
   scale_angular:

--- a/ridgeback_control/config/teleop_ps4.yaml
+++ b/ridgeback_control/config/teleop_ps4.yaml
@@ -6,9 +6,14 @@ teleop_twist_joy:
   scale_linear:
     x: 0.4
     y: 0.4
+  scale_linear_turbo:
+    x: 1.1
+    y: 1.1
   axis_angular:
     yaw: 3
   scale_angular:
+    yaw: 0.5
+  scale_angular_turbo:
     yaw: 0.5
   enable_button: 4
   enable_turbo_button: 5


### PR DESCRIPTION
We define a turbo button, but don't actually set the gains; this means pressing B5 uses the default 0.0 multiplier, causing the robot to stop.

~~This MR adds 1.1x multipliers to the linear speed (maximum advertised speed is 1.1m/s) but keeps the same angular maximum.~~

This MR uses the normal, non-turbo multipliers, allowing either button to be held to enable driving at normal speeds.

Tested on an integration project prior to shipping (and then reverted). Integration reports it worked as expected.